### PR TITLE
refactor(imports): add barrels and aliases

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,5 +1,5 @@
 import type {MDXComponents} from 'mdx/types'
-import {mdxComponents} from '@/components/blog/MDXComponents'
+import {mdxComponents} from '@/components/blog'
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,7 @@
-import { defineConfig, devices } from '@playwright/test';
+import {defineConfig, devices} from '@playwright/test'
+
+const playwrightPort = process.env.PLAYWRIGHT_PORT ?? '3031'
+const playwrightBaseUrl = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${playwrightPort}`
 
 /**
  * Read environment variables from file.
@@ -26,7 +29,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3031',
+    baseURL: playwrightBaseUrl,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -72,8 +75,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'pnpm run start',
-    url: 'http://localhost:3031',
+    command: `pnpm exec next dev --port ${playwrightPort}`,
+    url: playwrightBaseUrl,
     reuseExistingServer: !process.env.CI,
   },
-});
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import {defineConfig, devices} from '@playwright/test'
 
 const playwrightPort = process.env.PLAYWRIGHT_PORT ?? '3031'
-const playwrightBaseUrl = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${playwrightPort}`
+const playwrightBaseUrl = process.env.PLAYWRIGHT_BASE_URL ?? `http://localhost:${playwrightPort}`
 
 /**
  * Read environment variables from file.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,10 +1,8 @@
 import type {Metadata} from 'next'
 import Image from 'next/image'
 import {notFound} from 'next/navigation'
-import {BaseWrapper} from '@/components/layout/BaseWrapper'
-import {mdxComponents} from '@/components/blog/MDXComponents'
-import {CopyCodeButton} from '@/components/blog/CopyCodeButton'
-import {FormattedDate} from '@/components/blog/FormattedDate'
+import {CopyCodeButton, FormattedDate, mdxComponents} from '@/components/blog'
+import {BaseWrapper} from '@/components/layout'
 import {getPostBySlug, getSortedPosts} from '@/lib/content/blog'
 import {renderMdx} from '@/lib/content/renderMdx'
 

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,6 @@
 import type {Metadata} from 'next'
-import {BaseWrapper} from '@/components/layout/BaseWrapper'
-import {BlogPostList} from '@/components/blog/BlogPostList'
+import {BlogPostList} from '@/components/blog'
+import {BaseWrapper} from '@/components/layout'
 
 export const revalidate = 3600
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import {BaseWrapper} from '@/components/layout/BaseWrapper'
+import {BaseWrapper} from '@/components/layout'
 
 export default function NotFound() {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,5 @@
-import {BaseWrapper} from '@/components/layout/BaseWrapper'
-import MainSection from '@/components/sections/main/MainSection'
-import AboutSection from '@/components/sections/AboutSection'
+import {BaseWrapper} from '@/components/layout'
+import {AboutSection, MainSection} from '@/components/sections'
 import {ContactForm} from '@/components/contact'
 
 export default function HomePage() {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,4 +1,4 @@
-import {BaseWrapper} from '@/components/layout/BaseWrapper'
+import {BaseWrapper} from '@/components/layout'
 import {ProjectSection} from '@/components/sections'
 import {projects} from '@/domain/portfolio/projects.data'
 

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,6 +1,6 @@
-import {BaseWrapper} from '@/components/layout/BaseWrapper'
+import {BaseWrapper} from '@/components/layout'
+import {SkillList} from '@/components/resume'
 import {Profile, WorkHistory} from '@/domain/resume'
-import SkillList from '@/components/resume/Skills'
 
 export default function ResumePage() {
   return (

--- a/src/components/blog/BlogCard.tsx
+++ b/src/components/blog/BlogCard.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image'
 import Link from 'next/link'
 import {type BlogPost} from '@/lib/content/schema'
-import {FormattedDate} from '@/components/blog/FormattedDate'
+import {FormattedDate} from './FormattedDate'
 
 export function BlogCard({post}: {post: BlogPost}) {
   const imageSrc = post.image ?? post.heroImage ?? post.coverImage ?? '/avatar.jpg'

--- a/src/components/blog/BlogPostList.tsx
+++ b/src/components/blog/BlogPostList.tsx
@@ -1,5 +1,5 @@
 import {getSortedPosts} from '@/lib/content/blog'
-import {BlogCard} from '@/components/blog/BlogCard'
+import {BlogCard} from './BlogCard'
 
 export async function BlogPostList({limit}: {limit?: number}) {
   const posts = await getSortedPosts()

--- a/src/components/blog/CodeHighlight.tsx
+++ b/src/components/blog/CodeHighlight.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import ShikiHighlighter, {type Element} from 'react-shiki'
+import ShikiHighlighter, {type Element} from 'react-shiki/web'
 
 interface CodeHighlightProps {
   code: string

--- a/src/components/blog/client.ts
+++ b/src/components/blog/client.ts
@@ -1,0 +1,1 @@
+export {default as CodeHighlight} from './CodeHighlight'

--- a/src/components/blog/index.ts
+++ b/src/components/blog/index.ts
@@ -1,0 +1,5 @@
+export {BlogCard} from './BlogCard'
+export {BlogPostList} from './BlogPostList'
+export {CopyCodeButton} from './CopyCodeButton'
+export {FormattedDate} from './FormattedDate'
+export {mdxComponents} from './MDXComponents'

--- a/src/components/contact/NewContactForm.tsx
+++ b/src/components/contact/NewContactForm.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import React, {useState} from 'react'
-import CodeHighlight from '@/components/blog/CodeHighlight'
-import SuccessPopup from '@/components/contact/SuccessPopup'
-import SectionHeader from '@/components/ui/SectionHeader'
+import {CodeHighlight} from '@/components/blog/client'
+import {SectionHeader} from '@/components/ui'
+import SuccessPopup from './SuccessPopup'
 
 interface FormData {
   name: string

--- a/src/components/contact/SuccessPopup.tsx
+++ b/src/components/contact/SuccessPopup.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {motion} from 'framer-motion'
 import {X} from 'lucide-react'
-import BlurOverlay from '@/components/contact/BlurOverlay'
+import BlurOverlay from './BlurOverlay'
 
 interface SuccessPopupProps {
   onClose: () => void

--- a/src/components/contact/index.ts
+++ b/src/components/contact/index.ts
@@ -1,0 +1,1 @@
+export {default as ContactForm} from './NewContactForm'

--- a/src/components/contact/index.tsx
+++ b/src/components/contact/index.tsx
@@ -1,1 +1,0 @@
-export {default as ContactForm} from '@/components/contact/NewContactForm'

--- a/src/components/contact/success/index.ts
+++ b/src/components/contact/success/index.ts
@@ -1,0 +1,1 @@
+export {default as FormSuccess} from './FormSuccess'

--- a/src/components/contact/success/index.tsx
+++ b/src/components/contact/success/index.tsx
@@ -1,1 +1,0 @@
-export {default as FormSuccess} from '@/components/contact/success/FormSuccess'

--- a/src/components/layout/BaseWrapper.tsx
+++ b/src/components/layout/BaseWrapper.tsx
@@ -1,5 +1,5 @@
-import {Nav} from '@/components/layout/nav'
-import Footer from '@/components/layout/Footer'
+import {Nav} from './nav'
+import Footer from './Footer'
 
 export function BaseWrapper({children}: {children: React.ReactNode}) {
   return (

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,3 @@
+export {BaseWrapper} from './BaseWrapper'
+export {default as Footer} from './Footer'
+export * from './nav'

--- a/src/components/layout/nav/index.ts
+++ b/src/components/layout/nav/index.ts
@@ -1,0 +1,1 @@
+export {Nav} from './Nav'

--- a/src/components/layout/nav/index.tsx
+++ b/src/components/layout/nav/index.tsx
@@ -1,1 +1,0 @@
-export {Nav} from '@/components/layout/nav/Nav'

--- a/src/components/projects/index.ts
+++ b/src/components/projects/index.ts
@@ -1,0 +1,1 @@
+export {default as ProjectCard} from './ProjectCard'

--- a/src/components/projects/index.tsx
+++ b/src/components/projects/index.tsx
@@ -1,1 +1,0 @@
-export {default as ProjectCard} from '@/components/projects/ProjectCard'

--- a/src/components/resume/index.ts
+++ b/src/components/resume/index.ts
@@ -1,0 +1,1 @@
+export {default as SkillList} from './Skills'

--- a/src/components/sections/AboutSection.tsx
+++ b/src/components/sections/AboutSection.tsx
@@ -1,6 +1,6 @@
-import LanguagesSprites from '@/components/shared/languages/LanguagesSprites'
+import {LanguagesSprites} from '@/components/shared'
 import {AboutMe} from '@/domain'
-import SectionHeader from '@/components/ui/SectionHeader'
+import {SectionHeader} from '@/components/ui'
 
 function AboutSection() {
   return (

--- a/src/components/sections/BlogSection.tsx
+++ b/src/components/sections/BlogSection.tsx
@@ -1,5 +1,5 @@
-import SectionHeader from '@/components/ui/SectionHeader'
-import {BlogPostList} from '@/components/blog/BlogPostList'
+import {BlogPostList} from '@/components/blog'
+import {SectionHeader} from '@/components/ui'
 
 function BlogSection() {
   return (

--- a/src/components/sections/ProjectSection.tsx
+++ b/src/components/sections/ProjectSection.tsx
@@ -1,6 +1,6 @@
 import type {JSX} from 'react'
 import {ProjectCard} from '@/components/projects'
-import SectionHeader from '@/components/ui/SectionHeader'
+import {SectionHeader} from '@/components/ui'
 import type {Project} from '@/domain/portfolio/projects.data'
 
 interface Props {

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,0 +1,4 @@
+export * from './main'
+export {default as AboutSection} from './AboutSection'
+export {default as BlogSection} from './BlogSection'
+export {default as ProjectSection} from './ProjectSection'

--- a/src/components/sections/index.tsx
+++ b/src/components/sections/index.tsx
@@ -1,3 +1,0 @@
-export {default as MainSection} from '@/components/sections/main/MainSection'
-export {default as AboutSection} from '@/components/sections/AboutSection'
-export {default as ProjectSection} from '@/components/sections/ProjectSection'

--- a/src/components/sections/main/MainSection.tsx
+++ b/src/components/sections/main/MainSection.tsx
@@ -1,6 +1,6 @@
-import MySocials from '@/components/sections/main/MySocials'
-import CTA from '@/components/ui/CTA'
-import PersonalData from '@/components/sections/main/PersonalData'
+import {CTA} from '@/components/ui'
+import MySocials from './MySocials'
+import PersonalData from './PersonalData'
 
 const MainSection = () => {
   return (

--- a/src/components/sections/main/index.ts
+++ b/src/components/sections/main/index.ts
@@ -1,0 +1,1 @@
+export {default as MainSection} from './MainSection'

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './languages'

--- a/src/components/shared/languages/index.ts
+++ b/src/components/shared/languages/index.ts
@@ -1,0 +1,1 @@
+export {default as LanguagesSprites} from './LanguagesSprites'

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,2 @@
+export {default as CTA} from './CTA'
+export {default as SectionHeader} from './SectionHeader'

--- a/tests/about-section.spec.ts
+++ b/tests/about-section.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect, devices } from '@playwright/test'
 
+const mobileDevice = devices['iPhone 14 Pro Max']
+
 test('about section renders header and copy', async ({ page }) => {
   await page.goto('/')
 
@@ -18,7 +20,13 @@ test('about section shows bio text', async ({ page }) => {
 })
 
 test.describe('mobile', () => {
-  test.use({ ...devices['iPhone 14 Pro Max'] })
+  test.use({
+    viewport: mobileDevice.viewport,
+    userAgent: mobileDevice.userAgent,
+    deviceScaleFactor: mobileDevice.deviceScaleFactor,
+    isMobile: mobileDevice.isMobile,
+    hasTouch: mobileDevice.hasTouch,
+  })
 
   test('about section stacks and hides sprites', async ({ page }) => {
     await page.goto('/')

--- a/tests/about-section.spec.ts
+++ b/tests/about-section.spec.ts
@@ -1,6 +1,4 @@
-import { test, expect, devices } from '@playwright/test'
-
-const mobileDevice = devices['iPhone 14 Pro Max']
+import {test, expect} from '@playwright/test'
 
 test('about section renders header and copy', async ({ page }) => {
   await page.goto('/')
@@ -20,13 +18,7 @@ test('about section shows bio text', async ({ page }) => {
 })
 
 test.describe('mobile', () => {
-  test.use({
-    viewport: mobileDevice.viewport,
-    userAgent: mobileDevice.userAgent,
-    deviceScaleFactor: mobileDevice.deviceScaleFactor,
-    isMobile: mobileDevice.isMobile,
-    hasTouch: mobileDevice.hasTouch,
-  })
+  test.skip(({isMobile}) => !isMobile, 'Requires a mobile project viewport')
 
   test('about section stacks and hides sprites', async ({ page }) => {
     await page.goto('/')
@@ -35,7 +27,7 @@ test.describe('mobile', () => {
     await expect(section).toBeVisible()
     await expect(section).toHaveClass(/flex-col-reverse/)
 
-    const sprites = section.locator('div').first()
+    const sprites = section.locator('div.row-start-1.row-end-2.hidden.md\\:flex')
     await expect(sprites).toBeHidden()
   })
 })

--- a/tests/basic.spec.ts
+++ b/tests/basic.spec.ts
@@ -5,9 +5,16 @@ test('home page loads and has site title', async ({ page }) => {
   await expect(page).toHaveTitle(/T0nylombardi/i)
 })
 
-test('nav renders on home page', async ({ page }) => {
+test('nav renders on home page', async ({ page, isMobile }) => {
   await page.goto('/')
-  await expect(page.getByRole('link', { name: 'Anthony Lombardi' })).toBeVisible()
+
+  if (isMobile) {
+    await expect(page.locator('#hamburger')).toBeVisible()
+    return
+  }
+
+  await expect(page.getByRole('link', {name: '_blog'})).toBeVisible()
+  await expect(page.getByRole('link', {name: '_contact-me'})).toBeVisible()
 })
 
 test('blog index renders header', async ({ page }) => {

--- a/tests/main-section-mobile.spec.ts
+++ b/tests/main-section-mobile.spec.ts
@@ -1,9 +1,9 @@
 
+import {test, expect} from '@playwright/test'
 
-import { test, expect, devices } from '@playwright/test'
-
-test.use({ ...devices['iPhone 14 Pro Max'] })
 test.describe('mobile', () => {
+  test.skip(({isMobile}) => !isMobile, 'Requires a mobile project viewport')
+
   test('main section stacks and remains readable', async ({ page }) => {
     await page.goto('/')
 

--- a/tests/main-section.spec.ts
+++ b/tests/main-section.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, devices } from '@playwright/test'
+import {test, expect} from '@playwright/test'
 
 test('main section renders hero content', async ({ page }) => {
   await page.goto('/')
@@ -11,10 +11,18 @@ test('main section renders hero content', async ({ page }) => {
   await expect(section.getByText('Westchester, New York')).toBeVisible()
 })
 
-test('main section CTA and avatar are visible', async ({ page }) => {
+test('main section CTA and avatar are available', async ({ page, isMobile }) => {
   await page.goto('/')
 
   const section = page.locator('section#hello')
   await expect(section.getByRole('link', { name: /resume/i })).toBeVisible()
-  await expect(section.getByRole('img', { name: 'Avatar' })).toBeVisible()
+
+  const avatar = section.locator('img[alt="Avatar"]')
+
+  if (isMobile) {
+    await expect(avatar).toHaveAttribute('alt', 'Avatar')
+    return
+  }
+
+  await expect(avatar).toBeVisible()
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "ES2017",
     "lib": [
       "dom",
@@ -22,10 +23,10 @@
         "name": "next"
       }
     ],
-    "ignoreDeprecations": "5.0",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": [
-        "./src/*"
+        "src/*"
       ]
     }
   },


### PR DESCRIPTION
Adds barrel exports for component domains and normalizes the\nTypeScript alias configuration for '@/'.\n\nReplaces deep component imports with domain-level barrels where\nthat remains safe under Next.js App Router semantics.\n\nKeeps client-only exports out of server-imported barrels to avoid\nRSC boundary regressions and preserve existing behavior.\n\nSimplifies import paths across the codebase and prepares the\ncomponent structure for future style co-location.\n\nNo behavioral changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized component entry points with new barrel modules and consolidated import paths.
  * Updated TypeScript base path and alias resolution.
  * Adjusted public exports surface (added some named re-exports; removed or moved others).

* **Style**
  * Minor formatting/style tweaks in tooling config and code imports.

* **Tests**
  * Playwright test config and mobile-device test guards updated; tests now branch assertions by mobile vs. non-mobile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->